### PR TITLE
to solve "label shock "

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/LabelPropagation.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/LabelPropagation.scala
@@ -58,7 +58,7 @@ object LabelPropagation {
       }.toMap
     }
     def vertexProgram(vid: VertexId, attr: Long, message: Map[VertexId, Long]): VertexId = {
-      if (message.isEmpty) attr else message.maxBy(_._2)._1
+      (attr ++ message).maxBy(e=>(e._2,e._1))._1
     }
     val initialMessage = Map[VertexId, Long]()
     Pregel(lpaGraph, initialMessage, maxIterations = maxSteps)(


### PR DESCRIPTION
the LabelPropagation often suffers "labe shock"， and the result of communities are often non-adjacent.
 I think the label of node  is  userful between adjacent supersteps, and the adjacent supersteps are relevant.
