### PR TITLE
improve labelPropagation

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/LabelPropagation.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/LabelPropagation.scala
@@ -58,7 +58,7 @@ object LabelPropagation {
       }.toMap
     }
     def vertexProgram(vid: VertexId, attr: Long, message: Map[VertexId, Long]): VertexId = {
-      (Map(attr->1L) ++ message).maxBy(e=>(e._2,e._1))._1
+      (Map(attr -> 1L) ++ message).maxBy(m => (m._2, m._1))._1
     }
     val initialMessage = Map[VertexId, Long]()
     Pregel(lpaGraph, initialMessage, maxIterations = maxSteps)(


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

In the labelPropagation of graphx lib, node is initialized with a unique
label and at every step each node adopts the label that most of its neighbors currently have, but ignore the label it currently have. I think it is unreasonable, because the labe a node had is also useful. When a node trend to has a stable label, this means there is an association between two iterations, so a node not only affected by its neighbors, but also its current label.
so I change the code, and use both the label of its neighbors and itself.

This iterative process densely connected groups of nodes form a consensus on a unique label to form
communities. But the communities of the LabelPropagation often discontinuous.
Because when the label that most of its neighbors currents have are many,e.g, node "0" has 6 neigbors labed {"1","1","2","2","3","3"},it maybe randomly select a label. in order to get a stable label of communities, and prevent the randomness, so I chose the max lable of node.

you can test graph with Edges: {10L->11L,10L->12L, 11L->12L,11L->14L,12L->14L,13L->14L,13L->15L,13L->16L,15L->16L,15L->17L,16L->17L };or dandelion shape {1L->2L,2L->7L,2L->3L,2L->4L,2L->5L,2L->6L},etc.
